### PR TITLE
ci(workflows): add permissions to workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -1,5 +1,9 @@
 name: Publish Any Commit
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/npm_bark.yml
+++ b/.github/workflows/npm_bark.yml
@@ -1,5 +1,8 @@
 name: npm_bark
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '30 1 * * *'


### PR DESCRIPTION
Potential fix for 
- [https://github.com/Theo-Messi/lumen/security/code-scanning/1](https://github.com/Theo-Messi/lumen/security/code-scanning/1)
- [https://github.com/Theo-Messi/lumen/security/code-scanning/2](https://github.com/Theo-Messi/lumen/security/code-scanning/2)
- [https://github.com/Theo-Messi/lumen/security/code-scanning/3](https://github.com/Theo-Messi/lumen/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. 

