### PR TITLE
refactor(Image): keep images aria-hidden true, no alt

### DIFF
--- a/docs/.vitepress/configs/socialLinks.ts
+++ b/docs/.vitepress/configs/socialLinks.ts
@@ -19,9 +19,7 @@ export const socialLinks: DefaultTheme.SocialLink[] = [
     ariaLabel: 'npm'
   },
   {
-    icon: {
-      svg: '<iconify-icon icon="twemoji:red-heart" style="font-size:1.2em" alt="Github Sponsors"></iconify-icon>'
-    },
+    icon: { svg: '<iconify-icon icon="twemoji:red-heart" style="font-size:1.2em" ></iconify-icon>' },
     link: 'https://i.theojs.cn/sponsor.webp',
     ariaLabel: 'Github Sponsors'
   }

--- a/docs/.vitepress/data/AsideData.ts
+++ b/docs/.vitepress/data/AsideData.ts
@@ -2,7 +2,7 @@ import type { AsideItem } from '@theojs/lumen'
 
 export const Aside_Data: AsideItem = [
   {
-    image: { src: 'https://i.theojs.cn/logo/bee_logo.webp', alt: '小蜜蜂 Logo' },
+    image: 'https://i.theojs.cn/logo/bee_logo.webp',
     promo: '小蜜蜂 618购物狂欢',
     info1: '全套餐推出8折优惠<span class="promo-text"> xmfxmf7 </span>',
     info2: '3年付更可享受<span class="promo-text"> 4.8 </span>折',
@@ -10,7 +10,7 @@ export const Aside_Data: AsideItem = [
     rel: 'sponsored noreferrer'
   },
   // {
-  //   image: { src: 'https://i.theojs.cn/logo/flyingbird.webp', alt: 'FlyingBird Logo' },
+  //   image: 'https://i.theojs.cn/logo/flyingbird.webp',
   //   promo: 'FlyingBird 520&618 特惠',
   //   info1: '月/季/半年付<span class="promo-text"> 85折: fb2561885 </span>',
   //   info2: '年付以上<span class="promo-text"> 64折: fb2561880 </span>',
@@ -18,7 +18,7 @@ export const Aside_Data: AsideItem = [
   //   rel: 'sponsored noreferrer'
   // },
   // {
-  //   image: { src: 'https://i.theojs.cn/logo/totoro.webp', alt: '龙猫云 Logo' },
+  //   image: 'https://i.theojs.cn/logo/totoro.webp',
   //   promo: '龙猫云618大促-低至48折',
   //   info1: '月/季/半年付<span class="promo-text"> 85折: spring85 </span>',
   //   info2: '年付以上<span class="promo-text"> 48折: spring80 </span>',
@@ -26,7 +26,7 @@ export const Aside_Data: AsideItem = [
   //   rel: 'sponsored noreferrer'
   // },
   // {
-  //   image: { src: 'https://i.theojs.cn/logo/qyt.webp', alt: '青云梯 Logo' },
+  //   image: 'https://i.theojs.cn/logo/qyt.webp',
   //   promo: '青云梯 618大促活动开启',
   //   info1: '月/季/半年付 <span class="promo-text"> 85折: wuyi85 </span>',
   //   info2: '年付以上<span class="promo-text"> 64折: wuyi80 </span>',
@@ -34,7 +34,7 @@ export const Aside_Data: AsideItem = [
   //   rel: 'sponsored noreferrer'
   // },
   // {
-  //   image: { src: 'https://i.theojs.cn/logo/galaxy_transparent_square.webp', alt: 'Galaxy 银河云Logo', crop: true },
+  //   image: { src: 'https://i.theojs.cn/logo/galaxy_transparent_square.webp', crop: true },
   //   promo: 'Galaxy 银河云 618购物节',
   //   info1: '月/季/半年付 <span class="promo-text"> 85折: wuyi85 </span>',
   //   info2: '年付以上 <span class="promo-text"> 64折: wuyi80 </span>',
@@ -42,14 +42,14 @@ export const Aside_Data: AsideItem = [
   //   rel: 'sponsored noreferrer'
   // },
   // {
-  //   image: { src: 'https://i.theojs.cn/docs/TNT.webp', alt: 'TNT Cloud Logo', crop: true },
+  //   image: { src: 'https://i.theojs.cn/docs/TNT.webp', crop: true },
   //   promo: 'TNT Cloud 618购物狂欢!',
   //   info1: '全场 <span class="promo-text"> 8折: Crazy618 </span>',
   //   link: 'https://itheo.top/tnt',
   //   rel: 'sponsored noreferrer'
   // },
   // {
-  //   image: { src: 'https://i.theojs.cn/logo/feitu.webp', alt: '飞兔云 Logo' },
+  //   image: 'https://i.theojs.cn/logo/feitu.webp',
   //   promo: '飞兔云 六一&端午 特惠',
   //   info1: '月/半年/年付 <span class="promo-text">85</span> 折 ',
   //   info2: '优惠券 <span class="promo-text"> 61@85 </span>',
@@ -57,37 +57,37 @@ export const Aside_Data: AsideItem = [
   //   rel: 'sponsored noreferrer'
   // },
   {
-    image: { src: 'https://i.theojs.cn/logo/flyingbird.webp', alt: 'FlyingBird Logo' },
+    image: 'https://i.theojs.cn/logo/flyingbird.webp',
     promo: 'FlyingBird',
     link: 'https://itheo.top/flyingbird',
     rel: 'sponsored noreferrer'
   },
   {
-    image: { src: 'https://i.theojs.cn/logo/totoro.webp', alt: '龙猫云 Logo' },
+    image: 'https://i.theojs.cn/logo/totoro.webp',
     promo: 'Totoro Cloud - 龙猫云',
     link: 'https://itheo.top/totoro',
     rel: 'sponsored noreferrer'
   },
   {
-    image: { src: 'https://i.theojs.cn/logo/qyt.webp', alt: '青云梯 Logo' },
+    image: 'https://i.theojs.cn/logo/qyt.webp',
     promo: '青云梯',
     link: 'https://itheo.top/qyt',
     rel: 'sponsored noreferrer'
   },
   {
-    image: { src: 'https://i.theojs.cn/logo/galaxy_transparent_square.webp', alt: 'Galaxy 银河云Logo', crop: true },
+    image: { src: 'https://i.theojs.cn/logo/galaxy_transparent_square.webp', crop: true },
     promo: '银河云',
     link: 'https://itheo.top/yhy',
     rel: 'sponsored noreferrer'
   },
   {
-    image: { src: 'https://i.theojs.cn/docs/TNT.webp', alt: 'TNT Cloud Logo', crop: true },
+    image: { src: 'https://i.theojs.cn/docs/TNT.webp', crop: true },
     promo: 'TNT Cloud',
     link: 'https://itheo.top/tnt',
     rel: 'sponsored noreferrer'
   },
   {
-    image: { src: 'https://i.theojs.cn/logo/feitu.webp', alt: '飞兔云 Logo' },
+    image: 'https://i.theojs.cn/logo/feitu.webp',
     promo: '飞兔云',
     link: 'https://itheo.top/feitu',
     rel: 'sponsored noreferrer'
@@ -99,14 +99,14 @@ export const Aside_Data: AsideItem = [
     rel: 'sponsored noreferrer'
   },
   {
-    image: { src: 'https://i.theojs.cn/logo/avatar-128.webp', alt: 'Theo-Docs Logo' },
+    image: 'https://i.theojs.cn/logo/avatar-128.webp',
     name: 'Theo-Docs',
     hide1: '流媒体观影',
     hide2: '一站式服务',
     link: 'https://doc.theojs.cn/'
   },
   {
-    image: { src: 'https://i.theojs.cn/logo/avatar-128.webp', alt: '玄学宝典 Logo' },
+    image: 'https://i.theojs.cn/logo/avatar-128.webp',
     name: '玄学宝典',
     hide1: '传世经典著作',
     hide2: '山医命相卜',

--- a/docs/guide/comment.md
+++ b/docs/guide/comment.md
@@ -11,7 +11,7 @@ description: 了解如何通过 @theojs/lumen 插件将 Waline 评论系统集�
   :grid="2"
   :items="[
     {
-      image: { src: 'https://waline.js.org/logo.png', alt: 'waline icon' },
+      image: 'https://waline.js.org/logo.png',
       name: '如何部署请查看 waline 文档',
       desc: '一款简洁、安全的评论系统。',
       link: 'https://waline.js.org/guide/get-started/'
@@ -67,7 +67,7 @@ export const Waline_Data: WalineData = {
 }
 ```
 
-### 接口说明 <Pill :image="{ src: 'https://waline.js.org/logo.png', alt: 'waline icon' }" name="查看 waline 接口说明文档" link="https://waline.js.org/reference/client/props.html" />
+### 接口说明 <Pill image="https://waline.js.org/logo.png" name="查看 waline 接口说明文档" link="https://waline.js.org/reference/client/props.html" />
 
 ::: tip
 `path` 属性已通过 **VitePress** 提供的 `useRoute()` 自动获取，一般无需手动设置；**如有特殊需求，也可以自行覆盖**。
@@ -141,4 +141,4 @@ hero:
 
 ### CSS 变量
 
-已预设 <Pill icon="unjs:theme-colors" name="部分 CSS 变量" link="https://github.com/Theo-Messi/lumen/blob/main/src/style/components-var.css" />，如需进一步自定义，可参考 <Pill :image="{ src: 'https://waline.js.org/logo.png', alt: 'waline icon' }" name="Waline 官方文档" link="https://waline.js.org/reference/client/style.html" /> 通过覆盖样式实现个性化调整。
+已预设 <Pill icon="unjs:theme-colors" name="部分 CSS 变量" link="https://github.com/Theo-Messi/lumen/blob/main/src/style/components-var.css" />，如需进一步自定义，可参考 <Pill image="https://waline.js.org/logo.png" name="Waline 官方文档" link="https://waline.js.org/reference/client/style.html" /> 通过覆盖样式实现个性化调整。

--- a/docs/guide/example/BoxCube-image.vue
+++ b/docs/guide/example/BoxCube-image.vue
@@ -3,7 +3,7 @@
   :items="[
     // 图片
     {
-      image: { src: 'https://i.theojs.cn/logo/alipay.svg', alt: 'alipay icon' },
+      image: 'https://i.theojs.cn/logo/alipay.svg',
       name: '支付宝',
       link: 'https://i.theojs.cn/alipay.webp'
     },
@@ -12,7 +12,6 @@
       image: {
         light: 'https://i.theojs.cn/logo/github.svg',
         dark: 'https://i.theojs.cn/logo/github-dark.svg',
-        alt: 'github icon',
         crop: true
       },
       size: 48,

--- a/docs/guide/example/Card-image.vue
+++ b/docs/guide/example/Card-image.vue
@@ -3,7 +3,7 @@
   :items="[
     // 普通图片
     {
-      image: { src: 'https://i.theojs.cn/logo/alipay.svg', alt: 'alipay icon' },
+      image: 'https://i.theojs.cn/logo/alipay.svg',
       name: '支付宝',
       desc: '移动支付平台，提供便捷的在线支付和转账服务',
       link: 'https://i.theojs.cn/alipay.webp'
@@ -13,8 +13,7 @@
       image: {
         light: 'https://i.theojs.cn/logo/github.svg',
         dark: 'https://i.theojs.cn/logo/github-dark.svg',
-        crop: true,
-        alt: 'github icon'
+        crop: true
       },
       name: 'GitHub',
       desc: '全球最大代码托管平台，支持版本控制和协作开发。',

--- a/docs/guide/example/Links-image.vue
+++ b/docs/guide/example/Links-image.vue
@@ -3,7 +3,7 @@
   :items="[
     // 普通图片
     {
-      image: { src: 'https://i.theojs.cn/logo/alipay.svg', alt: 'alipay icon' },
+      image: 'https://i.theojs.cn/logo/alipay.svg',
       name: '支付宝',
       desc: '移动支付平台，提供便捷的在线支付和转账服务',
       link: 'https://i.theojs.cn/alipay.webp'
@@ -13,8 +13,7 @@
       image: {
         light: 'https://i.theojs.cn/logo/github.svg',
         dark: 'https://i.theojs.cn/logo/github-dark.svg',
-        crop: true,
-        alt: 'github icon'
+        crop: true
       },
       name: 'GitHub',
       desc: '全球最大代码托管平台，支持版本控制和协作开发。',

--- a/docs/guide/example/Pill-image.vue
+++ b/docs/guide/example/Pill-image.vue
@@ -1,16 +1,11 @@
 <!-- 图片 -->
-<Pill
-  :image="{ src: 'https://i.theojs.cn/logo/alipay.svg', alt: 'github icon' }"
-  name="支付宝"
-  link="https://i.theojs.cn/alipay.webp"
-/>
+<Pill image="https://i.theojs.cn/logo/alipay.svg" name="支付宝" link="https://i.theojs.cn/alipay.webp" />
 
 <!-- 深浅模式的图片 -->
 <Pill
   :image="{
     light: 'https://i.theojs.cn/logo/github.svg',
     dark: 'https://i.theojs.cn/logo/github-dark.svg',
-    alt: 'github icon',
     crop: true
   }"
   name="GitHub"

--- a/docs/guide/type.md
+++ b/docs/guide/type.md
@@ -16,6 +16,6 @@ export type IconType =
 ```ts
 export type ImageType =
   | string
-  | { src: string; crop?: boolean; alt?: AltType; [prop: string]: any }
-  | { light: string; dark: string; crop?: boolean; alt?: AltType; [prop: string]: any }
+  | { src: string; crop?: boolean; [prop: string]: any }
+  | { light: string; dark: string; crop?: boolean; [prop: string]: any }
 ```

--- a/docs/guide/vid.md
+++ b/docs/guide/vid.md
@@ -7,7 +7,7 @@ description: 了解如何使用 @theojs/lumen 插件提供的视频组件 (Vid)�
 
 该组件支持多种主流视频平台的视频嵌入，并允许通过自定义链接插入任意视频源。通过简洁直观的属性配置，可轻松集成 YouTube、Bilibili、腾讯视频、优酷、Vimeo 等平台，确保响应式布局与良好的观看体验。
 
-- **支持多平台**：内置支持 <Pill icon="logos:youtube-icon" name="YouTube" link="https://www.youtube.com/" /><Pill :icon="{ icon: 'simple-icons:bilibili', color: '#00A1D6' }" name="Bilibili" link="https://www.bilibili.com/" /><Pill :image="{ src: 'https://v.qq.com/favicon.ico', alt: '腾讯视频 icon' }" name="腾讯视频" link="https://v.qq.com/" /><Pill :image="{ src: 'https://img.alicdn.com/imgextra/i2/O1CN01BeAcgL1ywY0G5nSn8_!!6000000006643-2-tps-195-195.png', alt: '优酷视频 icon' }" name="优酷视频" link="https://www.youku.com/" /><Pill icon="logos:vimeo-icon" name="Vimeo" link="https://vimeo.com" />，只需提供对应平台标识 `is` 和视频 ID `id` 即可。
+- **支持多平台**：内置支持 <Pill icon="logos:youtube-icon" name="YouTube" link="https://www.youtube.com/" /><Pill :icon="{ icon: 'simple-icons:bilibili', color: '#00A1D6' }" name="Bilibili" link="https://www.bilibili.com/" /><Pill image="https://v.qq.com/favicon.ico" name="腾讯视频" link="https://v.qq.com/" /><Pill image="https://img.alicdn.com/imgextra/i2/O1CN01BeAcgL1ywY0G5nSn8_!!6000000006643-2-tps-195-195.png" name="优酷视频" link="https://www.youku.com/" /><Pill icon="logos:vimeo-icon" name="Vimeo" link="https://vimeo.com" />，只需提供对应平台标识 `is` 和视频 ID `id` 即可。
 - **自定义视频链接**：也可直接通过 `src` 属性插入自定义视频链接，适用于 MP4 文件或其他视频源。
 - **响应式设计**：自动适配不同屏幕尺寸，兼容移动端与桌面端，保证视频比例和显示效果。
 - **使用简便**：清晰的属性接口，无需额外配置，快速嵌入视频。

--- a/src/components/common/LmImage.vue
+++ b/src/components/common/LmImage.vue
@@ -20,8 +20,6 @@ const resImage = computed(() => {
   return undefined
 })
 
-const resAlt = computed(() => (typeof props.image === 'object' && props.image.alt ? props.image.alt : ''))
-
 const resCrop = computed(() => {
   return typeof props.image === 'object' && 'crop' in props.image ? Boolean(props.image.crop) : false
 })
@@ -37,10 +35,10 @@ const resAttrs = computed(() => {
   <img
     :class="resCrop ? 'crop' : undefined"
     :src="resImage ? withBase(resImage) : undefined"
-    :alt="resAlt"
     :width="size"
     :height="size"
     loading="lazy"
+    aria-hidden="true"
     v-bind="typeof image === 'string' ? $attrs : { ...resAttrs, ...$attrs }"
   />
 </template>

--- a/src/components/common/LmImage.vue
+++ b/src/components/common/LmImage.vue
@@ -39,6 +39,7 @@ const resAttrs = computed(() => {
     :height="size"
     loading="lazy"
     aria-hidden="true"
+    alt=""
     v-bind="typeof image === 'string' ? $attrs : { ...resAttrs, ...$attrs }"
   />
 </template>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,8 +2,6 @@ import type { WalineProps } from '@waline/client/full'
 
 /** 图标和图片的类型 */
 export type IconImageMode = string | { light: string; dark: string }
-/** Alt 文本类型 */
-export type AltType = string | undefined
 /** 尺寸类型 */
 export type SizeType = null | string | number
 /** 链接类型 */
@@ -22,8 +20,8 @@ export type IconType =
 
 export type ImageType =
   | string
-  | { src: string; crop?: boolean; alt?: AltType; [prop: string]: any }
-  | { light: string; dark: string; crop?: boolean; alt?: AltType; [prop: string]: any }
+  | { src: string; crop?: boolean; [prop: string]: any }
+  | { light: string; dark: string; crop?: boolean; [prop: string]: any }
 
 /** DocPill 接口 */
 export interface PillItem {


### PR DESCRIPTION
**This PR updates the default rendering behavior of the `Image` component to align with the `Icon` component:**

- By default, the Image component no longer requires an `alt` attribute and automatically adds `aria-hidden="true"` and an empty `alt=""` to improve accessibility;
- To provide semantic meaning with an `alt` attribute, use the following format:

```ts
image: { src: 'image-url', alt: 'description text', 'aria-hidden': 'false' }
